### PR TITLE
Cleaned up some space and added logging to visible via docker logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM debian:sid
+FROM debian:jessie-backports
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -qq update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -qq -y install zlib1g-dev gcc make git autoconf autogen automake pkg-config  
+RUN apt-get update \
+	&& apt-get -y install zlib1g-dev gcc make git autoconf autogen automake pkg-config \
+	&& rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/firehol/netdata.git netdata.git --depth=1 && \
-   cd netdata.git && \
-   ./netdata-installer.sh
+RUN git clone https://github.com/firehol/netdata.git netdata.git --depth=1 \
+	&& cd netdata.git && ./netdata-installer.sh && rm -rf /netdata.git
+
+RUN ln -sf /dev/stdout /var/log/netdata/access.log \
+	&& ln -sf /dev/stdout /var/log/netdata/debug.log \
+	&& ln -sf /dev/stderr /var/log/netdata/error.log 
 
 EXPOSE 19999
 


### PR DESCRIPTION
I was inspired by your dockerization of netdata but thought it would be better to submit some suggestions I found useful while playing around with it directly to you.

I know the discussion was for an Alpine base but jessie was more comfortable for me to test against as I already had the image locally. The biggest change I did was enable docker logs <container> to now show the netdata access, error and debug logs without needing to exec in and view the logs. I also noticed that apt cache and the git repo was taking space up on disk (not much but some) so I added in a step to remove them.

Thanks for doing the ground work and I hope this helps you as you helped me.
